### PR TITLE
Link to GitHub docs for terms in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A great example repo you can fork to your heart’s content, that serves as a la
 
 The first thing you want to do with this repo is quite likely [**fork it**](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo).  Use the Fork button in the top-right section of the page to do this.
 
-Once you’re on your fork, you can experiment however you like with it, play with [branches](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-branches), [issues](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/about-issues), [milestones](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/about-milestones), [labels](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/managing-labels), the [wiki](https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/about-wikis), and more.
+Once you’re on your fork, you can experiment however you like with it, play with [branches](https://guides.github.com/introduction/flow/), [issues](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/about-issues), [milestones](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/about-milestones), [labels](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/managing-labels), the [wiki](https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/about-wikis), and more.
 
 ## What’s in there?
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A great example repo you can fork to your heart’s content, that serves as a la
 
 ## Getting started
 
-The first thing you want to do with this repo is quite likely **fork it**.  Use the Fork button in the top-right section of the page to do this.
+The first thing you want to do with this repo is quite likely [**fork it**](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo).  Use the Fork button in the top-right section of the page to do this.
 
 Once you’re on your fork, you can experiment however you like with it, play with branches, issues, milestones, labels, the wiki, and more.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A great example repo you can fork to your heart’s content, that serves as a la
 
 The first thing you want to do with this repo is quite likely [**fork it**](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo).  Use the Fork button in the top-right section of the page to do this.
 
-Once you’re on your fork, you can experiment however you like with it, play with branches, issues, milestones, labels, the wiki, and more.
+Once you’re on your fork, you can experiment however you like with it, play with [branches](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-branches), [issues](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/about-issues), [milestones](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/about-milestones), [labels](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/managing-labels), the [wiki](https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/about-wikis), and more.
 
 ## What’s in there?
 


### PR DESCRIPTION
The README stresses that this repo is for fork but newbies may 
need more context so linking to GitHub documentation about fork.

We add even more links to GitHub docs for newbies: branches, issues, 
milestones, labels, and wiki.

